### PR TITLE
bottle is removed from homebrew

### DIFF
--- a/Formula/kudo-cli.rb
+++ b/Formula/kudo-cli.rb
@@ -6,7 +6,6 @@ class KudoCli < Formula
   desc "Interact with KUDO via the kubectl plugin"
   homepage "https://kudo.dev"
   version "0.19.0"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/kudobuilder/kudo/releases/download/v0.19.0/kudo_0.19.0_darwin_x86_64.tar.gz"

--- a/Formula/kuttl-cli.rb
+++ b/Formula/kuttl-cli.rb
@@ -6,7 +6,6 @@ class KuttlCli < Formula
   desc "Interact with KUTTL via the kubectl plugin"
   homepage "https://kuttl.dev"
   version "0.11.1"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
The use of `bottle` is removed from homebrew as of June 2021:  https://github.com/Homebrew/brew/pull/11239

Signed-off-by: Ken Sipe <kensipe@gmail.com>